### PR TITLE
Add server timeout to deployment scripts

### DIFF
--- a/deploy_linux_pnm.sh
+++ b/deploy_linux_pnm.sh
@@ -65,6 +65,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
 SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-5}"
 
 # Parse arguments
 ARGS=()
@@ -178,7 +179,7 @@ for ((i=0;;i++)); do
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
-    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
 done
 

--- a/deploy_linux_pnm.sh
+++ b/deploy_linux_pnm.sh
@@ -110,11 +110,11 @@ for i in "$PROGRAM_CLIENT_CERT_PATH $PROGRAM_CLIENT_KEY_PATH" "$DATA_CLIENT_CERT
     set -- $i
     if [ ! -f $1 ] || [ ! -f $2 ]; then
         echo "=============Generating $1 and $2"
-        openssl ecparam -name prime256v1 -genkey > $2 || exit
+        openssl ecparam -name prime256v1 -genkey > $2 || exit 1
         openssl req -x509 \
             -key $2 \
             -out $1 \
-            -config $CERT_CONF_PATH || exit
+            -config $CERT_CONF_PATH || exit 1
     fi
 done
 
@@ -140,13 +140,13 @@ $POLICY_GENERATOR_PATH \
     --capability "/$PROGRAM_DIR/:x,/$OUTPUT_DIR/:r,stdout:r,stderr:r" \
     --program-binary $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --capability "/$PROGRAM_DIR/:r,/$PROGRAM_DATA_DIR/:r,/$VIDEO_INPUT_DIR/:r,/program_internal/:rw,/$OUTPUT_DIR/:w,stdout:w,stderr:w" \
-    --output-policy-file $POLICY_PATH || exit
+    --output-policy-file $POLICY_PATH || exit 1
 
 
 
 echo "=============Preparing native module sandboxer"
-mkdir -p /tmp/nmm || exit
-cp -a $NATIVE_MODULE_SANDBOXER_PATH /tmp/nmm || exit
+mkdir -p /tmp/nmm || exit 1
+cp -a $NATIVE_MODULE_SANDBOXER_PATH /tmp/nmm || exit 1
 
 
 
@@ -161,8 +161,8 @@ sleep 5
 
 
 echo "=============Provisioning attestation personalities"
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
 
 
 
@@ -177,7 +177,7 @@ echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
     if [ $i -ge $SERVER_ATTEMPTS ]; then
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
-        exit
+        exit 1
     fi
     echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
@@ -199,19 +199,19 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $YOLOV3_CFG_PATH_REMOTE=$YOLOV3_CFG_PATH_LOCAL \
     --data $YOLOV3_WEIGHTS_PATH_REMOTE=$YOLOV3_WEIGHTS_PATH_LOCAL \
     --identity $DATA_CLIENT_CERT_PATH \
-    --key $DATA_CLIENT_KEY_PATH || exit
+    --key $DATA_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning video"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $INPUT_VIDEO_PATH_REMOTE=$INPUT_VIDEO_PATH_LOCAL \
     --identity $VIDEO_CLIENT_CERT_PATH \
-    --key $VIDEO_CLIENT_KEY_PATH || exit
+    --key $VIDEO_CLIENT_KEY_PATH || exit 1
 
 echo "=============Requesting computation"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --compute $PROGRAM_PATH_REMOTE \
     --identity $RESULT_CLIENT_CERT_PATH \
-    --key $RESULT_CLIENT_KEY_PATH || exit
+    --key $RESULT_CLIENT_KEY_PATH || exit 1
 
 echo "=============Querying results (stdout and stderr)"
 dump=$(RUST_LOG=error $CLIENT_PATH $POLICY_PATH \

--- a/deploy_linux_pnm.sh
+++ b/deploy_linux_pnm.sh
@@ -64,7 +64,7 @@ POLICY_PATH="${POLICY_PATH:-policy.json}"
 PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cleanup.sh}"
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
-SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
+SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
 
 # Parse arguments
 ARGS=()
@@ -174,8 +174,8 @@ fi
 
 echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
-    if [ $i -ge $SERVER_TIMEOUT ]; then
-        echo "Server not ready after ${i}s. See log for more details. Terminating"
+    if [ $i -ge $SERVER_ATTEMPTS ]; then
+        echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
     echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break

--- a/deploy_linux_pnm.sh
+++ b/deploy_linux_pnm.sh
@@ -64,6 +64,7 @@ POLICY_PATH="${POLICY_PATH:-policy.json}"
 PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cleanup.sh}"
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
 
 # Parse arguments
 ARGS=()
@@ -172,9 +173,13 @@ fi
 
 
 echo "=============Waiting for veracruz server to be ready"
-while true; do
-        echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
-        sleep 1
+for ((i=0;;i++)); do
+    if [ $i -ge $SERVER_TIMEOUT ]; then
+        echo "Server not ready after ${i}s. See log for more details. Terminating"
+        exit
+    fi
+    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    sleep 1
 done
 
 

--- a/deploy_linux_wasm.sh
+++ b/deploy_linux_wasm.sh
@@ -64,6 +64,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
 SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-5}"
 
 # Parse arguments
 ARGS=()
@@ -171,7 +172,7 @@ for ((i=0;;i++)); do
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
-    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
 done
 

--- a/deploy_linux_wasm.sh
+++ b/deploy_linux_wasm.sh
@@ -63,7 +63,7 @@ POLICY_PATH="${POLICY_PATH:-policy.json}"
 PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cleanup.sh}"
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
-SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
+SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
 
 # Parse arguments
 ARGS=()
@@ -167,8 +167,8 @@ fi
 
 echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
-    if [ $i -ge $SERVER_TIMEOUT ]; then
-        echo "Server not ready after ${i}s. See log for more details. Terminating"
+    if [ $i -ge $SERVER_ATTEMPTS ]; then
+        echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
     echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break

--- a/deploy_linux_wasm.sh
+++ b/deploy_linux_wasm.sh
@@ -109,11 +109,11 @@ for i in "$PROGRAM_CLIENT_CERT_PATH $PROGRAM_CLIENT_KEY_PATH" "$DATA_CLIENT_CERT
     set -- $i
     if [ ! -f $1 ] || [ ! -f $2 ]; then
         echo "=============Generating $1 and $2"
-        openssl ecparam -name prime256v1 -genkey > $2 || exit
+        openssl ecparam -name prime256v1 -genkey > $2 || exit 1
         openssl req -x509 \
             -key $2 \
             -out $1 \
-            -config $CERT_CONF_PATH || exit
+            -config $CERT_CONF_PATH || exit 1
     fi
 done
 
@@ -139,7 +139,7 @@ $POLICY_GENERATOR_PATH \
     --capability "/$PROGRAM_DIR/:x,/$OUTPUT_DIR/:r,stdout:r,stderr:r" \
     --program-binary $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --capability "/$PROGRAM_DATA_DIR/:r,/$VIDEO_INPUT_DIR/:r,/program_internal/:rw,/$OUTPUT_DIR/:w,stdout:w,stderr:w" \
-    --output-policy-file $POLICY_PATH || exit
+    --output-policy-file $POLICY_PATH || exit 1
 
 
 
@@ -154,8 +154,8 @@ sleep 5
 
 
 echo "=============Provisioning attestation personalities"
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
 
 
 
@@ -170,7 +170,7 @@ echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
     if [ $i -ge $SERVER_ATTEMPTS ]; then
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
-        exit
+        exit 1
     fi
     echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
@@ -184,7 +184,7 @@ echo "=============Provisioning program"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --program $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --identity $PROGRAM_CLIENT_CERT_PATH \
-    --key $PROGRAM_CLIENT_KEY_PATH || exit
+    --key $PROGRAM_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning data"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
@@ -192,19 +192,19 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $YOLOV3_CFG_PATH_REMOTE=$YOLOV3_CFG_PATH_LOCAL \
     --data $YOLOV3_WEIGHTS_PATH_REMOTE=$YOLOV3_WEIGHTS_PATH_LOCAL \
     --identity $DATA_CLIENT_CERT_PATH \
-    --key $DATA_CLIENT_KEY_PATH || exit
+    --key $DATA_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning video"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $INPUT_VIDEO_PATH_REMOTE=$INPUT_VIDEO_PATH_LOCAL \
     --identity $VIDEO_CLIENT_CERT_PATH \
-    --key $VIDEO_CLIENT_KEY_PATH || exit
+    --key $VIDEO_CLIENT_KEY_PATH || exit 1
 
 echo "=============Requesting computation"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --compute $PROGRAM_PATH_REMOTE \
     --identity $RESULT_CLIENT_CERT_PATH \
-    --key $RESULT_CLIENT_KEY_PATH || exit
+    --key $RESULT_CLIENT_KEY_PATH || exit 1
 
 echo "=============Querying results (stdout and stderr)"
 dump=$(RUST_LOG=error $CLIENT_PATH $POLICY_PATH \

--- a/deploy_linux_wasm.sh
+++ b/deploy_linux_wasm.sh
@@ -63,6 +63,7 @@ POLICY_PATH="${POLICY_PATH:-policy.json}"
 PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cleanup.sh}"
 
 SERVER_LOG="${SERVER_LOG:-server.log}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
 
 # Parse arguments
 ARGS=()
@@ -165,9 +166,13 @@ fi
 
 
 echo "=============Waiting for veracruz server to be ready"
-while true; do
-        echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
-        sleep 1
+for ((i=0;;i++)); do
+    if [ $i -ge $SERVER_TIMEOUT ]; then
+        echo "Server not ready after ${i}s. See log for more details. Terminating"
+        exit
+    fi
+    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    sleep 1
 done
 
 

--- a/deploy_nitro_pnm.sh
+++ b/deploy_nitro_pnm.sh
@@ -66,7 +66,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
-SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
+SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
 
 # Parse arguments
 ARGS=()
@@ -171,8 +171,8 @@ fi
 
 echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
-    if [ $i -ge $SERVER_TIMEOUT ]; then
-        echo "Server not ready after ${i}s. See log for more details. Terminating"
+    if [ $i -ge $SERVER_ATTEMPTS ]; then
+        echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
     echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break

--- a/deploy_nitro_pnm.sh
+++ b/deploy_nitro_pnm.sh
@@ -67,6 +67,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
 SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-5}"
 
 # Parse arguments
 ARGS=()
@@ -175,7 +176,7 @@ for ((i=0;;i++)); do
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
-    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
 done
 

--- a/deploy_nitro_pnm.sh
+++ b/deploy_nitro_pnm.sh
@@ -66,6 +66,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
 
 # Parse arguments
 ARGS=()
@@ -169,9 +170,13 @@ fi
 
 
 echo "=============Waiting for veracruz server to be ready"
-while true; do
-        echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
-        sleep 1
+for ((i=0;;i++)); do
+    if [ $i -ge $SERVER_TIMEOUT ]; then
+        echo "Server not ready after ${i}s. See log for more details. Terminating"
+        exit
+    fi
+    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    sleep 1
 done
 
 

--- a/deploy_nitro_pnm.sh
+++ b/deploy_nitro_pnm.sh
@@ -96,7 +96,7 @@ set -- "${ARGS[@]}"
 echo "=============Killing components"
 killall -9 proxy_attestation_server $BACKEND-veracruz-server veracruz-client runtime_enclave_binary
 $PROXY_CLEANUP_SCRIPT_PATH || true
-nitro-cli terminate-enclave --all || exit
+nitro-cli terminate-enclave --all || exit 1
 
 
 
@@ -113,11 +113,11 @@ for i in "$PROGRAM_CLIENT_CERT_PATH $PROGRAM_CLIENT_KEY_PATH" "$DATA_CLIENT_CERT
     set -- $i
     if [ ! -f $1 ] || [ ! -f $2 ]; then
         echo "=============Generating $1 and $2"
-        openssl ecparam -name prime256v1 -genkey > $2 || exit
+        openssl ecparam -name prime256v1 -genkey > $2 || exit 1
         openssl req -x509 \
             -key $2 \
             -out $1 \
-            -config $CERT_CONF_PATH || exit
+            -config $CERT_CONF_PATH || exit 1
     fi
 done
 
@@ -143,7 +143,7 @@ $POLICY_GENERATOR_PATH \
     --capability "/$PROGRAM_DIR/:x,/$OUTPUT_DIR/:r,stdout:r,stderr:r" \
     --program-binary $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --capability "/$PROGRAM_DIR/:r,/$PROGRAM_DATA_DIR/:r,/$VIDEO_INPUT_DIR/:r,/program_internal/:rw,/$OUTPUT_DIR/:w,stdout:w,stderr:w" \
-    --output-policy-file $POLICY_PATH || exit
+    --output-policy-file $POLICY_PATH || exit 1
 
 
 
@@ -158,8 +158,8 @@ sleep 5
 
 
 echo "=============Provisioning attestation personalities"
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
 
 
 
@@ -174,7 +174,7 @@ echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
     if [ $i -ge $SERVER_ATTEMPTS ]; then
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
-        exit
+        exit 1
     fi
     echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
@@ -194,7 +194,7 @@ echo "=============Provisioning program"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --program $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --identity $PROGRAM_CLIENT_CERT_PATH \
-    --key $PROGRAM_CLIENT_KEY_PATH || exit
+    --key $PROGRAM_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning data"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
@@ -202,19 +202,19 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $YOLOV3_CFG_PATH_REMOTE=$YOLOV3_CFG_PATH_LOCAL \
     --data $YOLOV3_WEIGHTS_PATH_REMOTE=$YOLOV3_WEIGHTS_PATH_LOCAL \
     --identity $DATA_CLIENT_CERT_PATH \
-    --key $DATA_CLIENT_KEY_PATH || exit
+    --key $DATA_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning video"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $INPUT_VIDEO_PATH_REMOTE=$INPUT_VIDEO_PATH_LOCAL \
     --identity $VIDEO_CLIENT_CERT_PATH \
-    --key $VIDEO_CLIENT_KEY_PATH || exit
+    --key $VIDEO_CLIENT_KEY_PATH || exit 1
 
 echo "=============Requesting computation"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --compute $PROGRAM_PATH_REMOTE \
     --identity $RESULT_CLIENT_CERT_PATH \
-    --key $RESULT_CLIENT_KEY_PATH || exit
+    --key $RESULT_CLIENT_KEY_PATH || exit 1
 
 echo "=============Querying results (stdout and stderr)"
 dump=$(RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
@@ -240,4 +240,4 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
 echo "=============Killing components"
 killall -9 proxy_attestation_server $BACKEND-veracruz-server veracruz-client runtime_enclave_binary
 $PROXY_CLEANUP_SCRIPT_PATH || true
-nitro-cli terminate-enclave --all || exit
+nitro-cli terminate-enclave --all || exit 1

--- a/deploy_nitro_wasm.sh
+++ b/deploy_nitro_wasm.sh
@@ -65,7 +65,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
-SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
+SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
 
 # Parse arguments
 ARGS=()
@@ -170,8 +170,8 @@ fi
 
 echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
-    if [ $i -ge $SERVER_TIMEOUT ]; then
-        echo "Server not ready after ${i}s. See log for more details. Terminating"
+    if [ $i -ge $SERVER_ATTEMPTS ]; then
+        echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
     echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break

--- a/deploy_nitro_wasm.sh
+++ b/deploy_nitro_wasm.sh
@@ -66,6 +66,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
 SERVER_ATTEMPTS="${SERVER_ATTEMPTS:-60}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-5}"
 
 # Parse arguments
 ARGS=()
@@ -174,7 +175,7 @@ for ((i=0;;i++)); do
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
         exit
     fi
-    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
 done
 

--- a/deploy_nitro_wasm.sh
+++ b/deploy_nitro_wasm.sh
@@ -65,6 +65,7 @@ PROXY_CLEANUP_SCRIPT_PATH="${PROXY_CLEANUP_SCRIPT_PATH:-$VERACRUZ_PATH/proxy_cle
 
 NITRO_LOG="${NITRO_LOG:-nitro.log}"
 SERVER_LOG="${SERVER_LOG:-server.log}"
+SERVER_TIMEOUT="${SERVER_TIMEOUT:-60}"
 
 # Parse arguments
 ARGS=()
@@ -168,9 +169,13 @@ fi
 
 
 echo "=============Waiting for veracruz server to be ready"
-while true; do
-        echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
-        sleep 1
+for ((i=0;;i++)); do
+    if [ $i -ge $SERVER_TIMEOUT ]; then
+        echo "Server not ready after ${i}s. See log for more details. Terminating"
+        exit
+    fi
+    echo -n | telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
+    sleep 1
 done
 
 

--- a/deploy_nitro_wasm.sh
+++ b/deploy_nitro_wasm.sh
@@ -95,7 +95,7 @@ set -- "${ARGS[@]}"
 echo "=============Killing components"
 killall -9 proxy_attestation_server $BACKEND-veracruz-server veracruz-client runtime_enclave_binary
 $PROXY_CLEANUP_SCRIPT_PATH || true
-nitro-cli terminate-enclave --all || exit
+nitro-cli terminate-enclave --all || exit 1
 
 
 
@@ -112,11 +112,11 @@ for i in "$PROGRAM_CLIENT_CERT_PATH $PROGRAM_CLIENT_KEY_PATH" "$DATA_CLIENT_CERT
     set -- $i
     if [ ! -f $1 ] || [ ! -f $2 ]; then
         echo "=============Generating $1 and $2"
-        openssl ecparam -name prime256v1 -genkey > $2 || exit
+        openssl ecparam -name prime256v1 -genkey > $2 || exit 1
         openssl req -x509 \
             -key $2 \
             -out $1 \
-            -config $CERT_CONF_PATH || exit
+            -config $CERT_CONF_PATH || exit 1
     fi
 done
 
@@ -142,7 +142,7 @@ $POLICY_GENERATOR_PATH \
     --capability "/$PROGRAM_DIR/:x,/$OUTPUT_DIR/:r,stdout:r,stderr:r" \
     --program-binary $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --capability "/$PROGRAM_DATA_DIR/:r,/$VIDEO_INPUT_DIR/:r,/program_internal/:rw,/$OUTPUT_DIR/:w,stdout:w,stderr:w" \
-    --output-policy-file $POLICY_PATH || exit
+    --output-policy-file $POLICY_PATH || exit 1
 
 
 
@@ -157,8 +157,8 @@ sleep 5
 
 
 echo "=============Provisioning attestation personalities"
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
-curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1' --data-binary "@/opt/veraison/psa_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
+curl -X POST -H 'Content-Type: application/corim-unsigned+cbor; profile=http://aws.com/nitro' --data-binary "@/opt/veraison/nitro_corim.cbor" $PROVISIONING_SERVER_ADDRESS:$PROVISIONING_SERVER_PORT/endorsement-provisioning/v1/submit || exit 1
 
 
 
@@ -173,7 +173,7 @@ echo "=============Waiting for veracruz server to be ready"
 for ((i=0;;i++)); do
     if [ $i -ge $SERVER_ATTEMPTS ]; then
         echo "Server not ready after ${i} attempts. See log for more details. Terminating"
-        exit
+        exit 1
     fi
     echo -n | timeout $SERVER_TIMEOUT telnet $VC_SERVER_ADDRESS $VC_SERVER_PORT 2>/dev/null | grep "^Connected to" && break
     sleep 1
@@ -193,7 +193,7 @@ echo "=============Provisioning program"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --program $PROGRAM_PATH_REMOTE=$PROGRAM_PATH_LOCAL \
     --identity $PROGRAM_CLIENT_CERT_PATH \
-    --key $PROGRAM_CLIENT_KEY_PATH || exit
+    --key $PROGRAM_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning data"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
@@ -201,19 +201,19 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $YOLOV3_CFG_PATH_REMOTE=$YOLOV3_CFG_PATH_LOCAL \
     --data $YOLOV3_WEIGHTS_PATH_REMOTE=$YOLOV3_WEIGHTS_PATH_LOCAL \
     --identity $DATA_CLIENT_CERT_PATH \
-    --key $DATA_CLIENT_KEY_PATH || exit
+    --key $DATA_CLIENT_KEY_PATH || exit 1
 
 echo "=============Provisioning video"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --data $INPUT_VIDEO_PATH_REMOTE=$INPUT_VIDEO_PATH_LOCAL \
     --identity $VIDEO_CLIENT_CERT_PATH \
-    --key $VIDEO_CLIENT_KEY_PATH || exit
+    --key $VIDEO_CLIENT_KEY_PATH || exit 1
 
 echo "=============Requesting computation"
 RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
     --compute $PROGRAM_PATH_REMOTE \
     --identity $RESULT_CLIENT_CERT_PATH \
-    --key $RESULT_CLIENT_KEY_PATH || exit
+    --key $RESULT_CLIENT_KEY_PATH || exit 1
 
 echo "=============Querying results (stdout and stderr)"
 dump=$(RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
@@ -239,4 +239,4 @@ RUST_LOG=error $CLIENT_PATH $POLICY_PATH \
 echo "=============Killing components"
 killall -9 proxy_attestation_server $BACKEND-veracruz-server veracruz-client runtime_enclave_binary
 $PROXY_CLEANUP_SCRIPT_PATH || true
-nitro-cli terminate-enclave --all || exit
+nitro-cli terminate-enclave --all || exit 1


### PR DESCRIPTION
Should come in handy when the server fails for some reason.
It will then be possible to look at the log to see what happened, without having to wait for the workflow to time out (6h). Cf. https://github.com/veracruz-project/veracruz/pull/637